### PR TITLE
use enum genres and adjust podcasts/_form

### DIFF
--- a/app/models/podcast.rb
+++ b/app/models/podcast.rb
@@ -10,4 +10,26 @@ class Podcast < ApplicationRecord
   validates :language, presence: true
   validates :slug, presence: true
   validates :genres, presence: true
+  
+  enum genres: {
+    arts: "Arts", 
+    business: "Business", 
+    comedy: "Comedy", 
+    education: "Education", 
+    fiction: "Fiction", 
+    healthfitness: "Health & Fitness", 
+    history: "History", 
+    kidsfamily: "Kids & Family", 
+    leisure: "Leisure", 
+    music: "Music", 
+    news: "News", 
+    religionspirituality: "Religion & Spirituality", 
+    science: "Science", 
+    societyculture: "Society & Culture", 
+    sports: "Sports", 
+    tvfilm: "TV & Film", 
+    technology: "Technology"
+  }
+
+
 end

--- a/app/views/podcasts/_form.html.erb
+++ b/app/views/podcasts/_form.html.erb
@@ -13,7 +13,7 @@
   <%= f.input :email, label: "Email" %>
   <%= f.input :language, collection: ["繁體中文", "简体中文", "粵語", "English", "日本語", "한국어"], label: "語言" %>
   <%= f.input :slug, label: "好記短網址https://soundbar.tk/" %>
-  <%= f.input :genres, collection: ["Arts", "Business", "Comedy", "Education", "Fiction", "Health & Fitness", "History", "Kids & Family", "Leisure", "Music", "News", "Religion & Spirituality", "Science", "Society & Culture", "Sports", "TV & Film", "Technology"], label: "類別" %>
+  <%= f.input :genres, collection: Podcast.genres.values, label: "類別" %>
   <%= f.input :description, label: "描述" %>
   <%= f.input :subtitle, label: "Subtitle" %>
   <%= f.input :weblink, label: "網站連結" %>


### PR DESCRIPTION
在model/podcast新增enum, 將選單改成hash, 並調整_form的選單表示方式(簡單來說, 就是不用在 _form.html.erb 把選項一個一個寫出來, 只要寫Podcast.genres.values就會有預設選項了)