### PR TITLE
add cascade delete to foreign key

### DIFF
--- a/db/migrate/20210522022843_change_foreign_key_on_delete.rb
+++ b/db/migrate/20210522022843_change_foreign_key_on_delete.rb
@@ -1,0 +1,17 @@
+class ChangeForeignKeyOnDelete < ActiveRecord::Migration[6.1]
+  def change
+    remove_foreign_key "comments", "episodes"
+    remove_foreign_key "comments", "users"
+    remove_foreign_key "donations", "podcasts"
+    remove_foreign_key "episodes", "podcasts"
+    remove_foreign_key "subscriptions", "podcasts"
+    remove_foreign_key "subscriptions", "users"
+
+    add_foreign_key "comments", "episodes", on_delete: :cascade
+    add_foreign_key "comments", "users", on_delete: :cascade
+    add_foreign_key "donations", "podcasts", on_delete: :cascade
+    add_foreign_key "episodes", "podcasts", on_delete: :cascade
+    add_foreign_key "subscriptions", "podcasts", on_delete: :cascade
+    add_foreign_key "subscriptions", "users", on_delete: :cascade
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_05_21_082529) do
+ActiveRecord::Schema.define(version: 2021_05_22_022843) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -100,10 +100,10 @@ ActiveRecord::Schema.define(version: 2021_05_21_082529) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
-  add_foreign_key "comments", "episodes"
-  add_foreign_key "comments", "users"
-  add_foreign_key "donations", "podcasts"
-  add_foreign_key "episodes", "podcasts"
-  add_foreign_key "subscriptions", "podcasts"
-  add_foreign_key "subscriptions", "users"
+  add_foreign_key "comments", "episodes", on_delete: :cascade
+  add_foreign_key "comments", "users", on_delete: :cascade
+  add_foreign_key "donations", "podcasts", on_delete: :cascade
+  add_foreign_key "episodes", "podcasts", on_delete: :cascade
+  add_foreign_key "subscriptions", "podcasts", on_delete: :cascade
+  add_foreign_key "subscriptions", "users", on_delete: :cascade
 end


### PR DESCRIPTION
新增migration，在foreign_key的部分多加了 on_delete: :cascade ，這樣即使podcast下面有episode，也可以直接刪掉