### PR TITLE
前台-贊助頁面復刻 #80

### DIFF
--- a/app/javascript/styles/button.scss
+++ b/app/javascript/styles/button.scss
@@ -1,5 +1,5 @@
 .btn {
-  @apply rounded-lg font-medium px-4 py-2 shadow-xl hover:shadow-inner focus:outline-none transition duration-500 ease-in-out transform hover:-translate-x-0 hover:scale-105;
+  @apply rounded font-medium px-4 py-2 shadow-xl hover:shadow-inner focus:outline-none transition duration-500 ease-in-out transform hover:-translate-x-0 hover:scale-105;
 }
 
 .btn-primary {

--- a/app/javascript/styles/donate.scss
+++ b/app/javascript/styles/donate.scss
@@ -10,3 +10,24 @@
 #donateLinkInput::selection{
   @apply bg-gray-100 text-gray-400;
 }
+
+.donate_bg {
+  background: linear-gradient(rgb(62, 111, 139), rgb(31, 52, 71));
+}
+
+.donate_podcast {
+  @apply text-white text-3xl mx-auto m-2 pt-5 font-bold;
+}
+
+.donate_artist {
+  @apply text-white text-xl mx-auto m-2 font-light;
+}
+
+.donate_form {
+  @apply w-full border p-3 rounded duration-500 hover:border-titleblue;
+}
+
+.donate_message {
+  @apply w-full border p-5 rounded duration-500 hover:border-titleblue;
+}
+

--- a/app/javascript/styles/donate.scss
+++ b/app/javascript/styles/donate.scss
@@ -31,3 +31,6 @@
   @apply w-full border p-5 rounded duration-500 hover:border-titleblue;
 }
 
+.donate_cover {
+  @apply sm:w-60 sm:h-60;
+}

--- a/app/views/frontend/_header.html.erb
+++ b/app/views/frontend/_header.html.erb
@@ -3,6 +3,6 @@
     <%= link_to image_tag("logo_trans", size: "250x250"), "/#" %>
   </div>
   <form class="search-form border hover:border-blue-600 rounded flex my-auto mr-10">
-    <button class="search-btn focus:outline-none w-10 bg-white rounded-l text-gray-500 border-none p-2"><i class="fas fa-search"></i></button><input type="text" class="search-input focus:outline-none w-32 md:w-60 lg:w-72 bg-white rounded-r border-none p-2" placeholder="搜尋 Podcast">
+    <button class="search-btn focus:outline-none w-10 bg-white rounded-l text-gray-500 border-none p-2"><i class="fas fa-search"></i></button><input type="text" class="search-input focus:outline-none w-12 sm:w-40 md:w-60 lg:w-72 bg-white rounded-r border-none p-2" placeholder="搜尋 Podcast">
   </form>
 </header>

--- a/app/views/frontend/_header.html.erb
+++ b/app/views/frontend/_header.html.erb
@@ -3,6 +3,6 @@
     <%= link_to image_tag("logo_trans", size: "250x250"), "/#" %>
   </div>
   <form class="search-form border hover:border-blue-600 rounded flex my-auto mr-10">
-    <button class="search-btn focus:outline-none w-10 bg-white rounded-l text-gray-500 border-none p-2"><i class="fas fa-search"></i></button><input type="text" class="search-input focus:outline-none w-72 bg-white rounded-r border-none p-2" placeholder="搜尋 Podcast">
+    <button class="search-btn focus:outline-none w-10 bg-white rounded-l text-gray-500 border-none p-2"><i class="fas fa-search"></i></button><input type="text" class="search-input focus:outline-none w-32 md:w-60 lg:w-72 bg-white rounded-r border-none p-2" placeholder="搜尋 Podcast">
   </form>
 </header>

--- a/app/views/player/donations/new_donation.html.erb
+++ b/app/views/player/donations/new_donation.html.erb
@@ -9,19 +9,19 @@
     </div>
   </div>
   <div class="w-auto md:w-4/12">
-    <div class="w-full grid">
+    <div class="w-full h-full grid">
       <div class="">
         <%= simple_form_for @donation, url:  donate_player_podcast_path(@podcast.random_url)  do |f| %>
-        <div class="p-3"><%= f.input :amount, label: "一次性贊助", input_html: { class: "donate_form" } %></div>
-        <div class="p-3"><%= f.input :donator, label: "名稱", placeholder: "未填寫則顯示「匿名贊助者」", input_html: { class: "donate_form" } %></div>
-        <div class="p-3"><%= f.input :note, label: "留一段話鼓勵我吧！", input_html: { class: "donate_message" } %></div>
+        <div class="p-3 pr-5 pl-5"><%= f.input :amount, label: "一次性贊助", input_html: { class: "donate_form" } %></div>
+        <div class="p-3 pr-5 pl-5"><%= f.input :donator, label: "名稱", placeholder: "未填寫則顯示「匿名贊助者」", input_html: { class: "donate_form" } %></div>
+        <div class="p-3 pr-5 pl-5"><%= f.input :note, label: "留一段話鼓勵我吧！", input_html: { class: "donate_message" } %></div>
       </div>
-      <div class="relative bottom-0">
-        <div class="flex justify-center">
-          <div class=""><%= f.button :submit, "贊助", class: "btn-primary" %></div>
+      <div>
+        <div class="flex flex-col justify-center flex-grow md:pt-64 pt-5 pr-7 pl-7 pb-3">
+          <div><%= f.button :submit, "贊助", class: "btn-primary w-full" %></div>
         </div>
         <% end %>
-        <footer class="flex text-xs font-light justify-center pt-3">
+        <footer class="flex text-xs font-light justify-center pb-3">
           <span class="pr-1">Powered</span>
           <span class="pr-1">by</span>
           <span class="text-titleblue">SoundBar</span>

--- a/app/views/player/donations/new_donation.html.erb
+++ b/app/views/player/donations/new_donation.html.erb
@@ -2,7 +2,7 @@
   <div class="my-auto md:w-8/12">
     <div class="donate_bg md:h-screen grid justify-center items-center">
       <div class="grid">
-        <span><%= image_tag(@podcast.cover.url, size: "250x250") if @podcast.cover? %></span>
+        <span class="donate_cover"><%= image_tag(@podcast.cover.url, size: "250x250") if @podcast.cover? %></span>
         <p class="donate_podcast"><%= @podcast.name %></p>
         <p class="donate_artist"><%= @podcast.artist %></p>
       </div>

--- a/app/views/player/donations/new_donation.html.erb
+++ b/app/views/player/donations/new_donation.html.erb
@@ -1,25 +1,33 @@
-<%= link_to "返回節目", podcast_path(@podcast) %>
-<br>
-<h1>贊助　<%= @podcast.name %></h1>
-
-<p>
-  <strong>Cover:</strong>
-  <%= image_tag(@podcast.cover.url) if @podcast.cover? %>
-</p>
-
-<ul>
-  <li>創作者：<%= @podcast.artist %></li>
-  <li>類別：<%= @podcast.genres %></li>
-  <li>語言：<%= @podcast.language %></li>
-  <li>描述：<%= @podcast.description %></li>
-</ul>
-
-<h1><%= @podcast.donate_title %></h1>
-
-<%= simple_form_for @donation, url:  donate_player_podcast_path(@podcast.random_url)  do |f| %>
-  <%= f.input :donator, label: "名稱", placeholder: "未填寫則顯示「匿名贊助者」" %>
-  <%= f.input :note, label: "留一段話鼓勵我吧！" %>
-  <%= f.input :amount, label: "贊助金額", hint: "不得小於50元" %>
-  <%= f.button :submit %>
-<% end %>
+<div class="grid md:flex">
+  <div class="my-auto md:w-8/12">
+    <div class="donate_bg md:h-screen grid justify-center items-center">
+      <div class="grid">
+        <span><%= image_tag(@podcast.cover.url, size: "250x250") if @podcast.cover? %></span>
+        <p class="donate_podcast"><%= @podcast.name %></p>
+        <p class="donate_artist"><%= @podcast.artist %></p>
+      </div>
+    </div>
+  </div>
+  <div class="w-auto md:w-4/12">
+    <div class="w-full grid">
+      <div class="">
+        <%= simple_form_for @donation, url:  donate_player_podcast_path(@podcast.random_url)  do |f| %>
+        <div class="p-3"><%= f.input :amount, label: "一次性贊助", input_html: { class: "donate_form" } %></div>
+        <div class="p-3"><%= f.input :donator, label: "名稱", placeholder: "未填寫則顯示「匿名贊助者」", input_html: { class: "donate_form" } %></div>
+        <div class="p-3"><%= f.input :note, label: "留一段話鼓勵我吧！", input_html: { class: "donate_message" } %></div>
+      </div>
+      <div class="relative bottom-0">
+        <div class="flex justify-center">
+          <div class=""><%= f.button :submit, "贊助", class: "btn-primary" %></div>
+        </div>
+        <% end %>
+        <footer class="flex text-xs font-light justify-center pt-3">
+          <span class="pr-1">Powered</span>
+          <span class="pr-1">by</span>
+          <span class="text-titleblue">SoundBar</span>
+        </footer>
+      </div>
+    </div>
+  </div>
+</div>
 

--- a/app/views/player/episodes/show.html.erb
+++ b/app/views/player/episodes/show.html.erb
@@ -62,13 +62,13 @@
           <div class="pb-10 pl-10">
             <%= f.button :submit, "送出留言", class: "btn btn-primary" %>
           </div>
-          <ul id="comment_area">
-          <% @comments.each do |comment| %>
-            <li><%= comment.content %></li>
           <% end %>
-          </ul>
-            <% end %>
       </div>
+      <ul id="comment_area">
+      <% @comments.each do |comment| %>
+        <li><%= comment.content %></li>
+      <% end %>
+      </ul>
     </div>
   </div>
   <div class="player flex w-full justify-center fixed bottom-0 rounded-md pb-5 pt-5 bg-titleblue hidden">

--- a/app/views/player/episodes/show.html.erb
+++ b/app/views/player/episodes/show.html.erb
@@ -28,7 +28,7 @@
         <%= image_tag(@podcast.cover.url, size: "230x230") if @podcast.cover? %>
       </div>
       <div class="mt-10">
-        <div class="text-white text-4xl">EP<%= @episode.episode %>｜<%= @episode.title %></div>
+        <div class="text-white text-4xl"><%= @episode.title %></div>
         <div class="mt-8 text-gray-400">
           <span class="pr-2"><i class="far fa-calendar-alt"></i></span>
           <span class=""><%= @episode.created_at.strftime('%Y-%m-%d') %></div></span>
@@ -62,12 +62,12 @@
           <div class="pb-10 pl-10">
             <%= f.button :submit, "送出留言", class: "btn btn-primary" %>
           </div>
+          <ul id="comment_area">
+          <% @comments.each do |comment| %>
+            <li><%= comment.content %></li>
+          <% end %>
+          </ul>
             <% end %>
-        <ul id="comment_area">
-        <% @comments.each do |comment| %>
-          <li><%= comment.content %></li>
-        <% end %>
-        </ul>
       </div>
     </div>
   </div>

--- a/app/views/player/podcasts/browse.html.erb
+++ b/app/views/player/podcasts/browse.html.erb
@@ -1,11 +1,4 @@
-  <header class="flex justify-between bg-indigo">
-    <div class="flex m-4 justify-center md:justify-start">
-      <%= link_to image_tag("logo_trans", size: "250x250"), "/#" %>
-    </div>
-    <form class="search-form border hover:border-blue-600 rounded flex my-auto mr-10">
-      <button class="search-btn focus:outline-none w-10 bg-white rounded-l text-gray-500 border-none p-2"><i class="fas fa-search"></i></button><input type="text" class="search-input focus:outline-none w-auto bg-white rounded-r border-none p-2" placeholder="搜尋 Podcast">
-    </form>
-  </header>
+<%= render '/frontend/header' %>
 
 <div class="bg-indigo">
   <div class="max-w-screen-lg mx-auto h-screen">
@@ -25,8 +18,10 @@
         <% @podcasts.each do |podcast| %>
         <div class="cover_line imgBox">
           <div class="">
-            <div class="covers">
-            <%= link_to image_tag("https://picsum.photos/200/200/?random=1"), player_podcast_path(podcast.random_url)  %>
+          <div class="covers">
+          <%= link_to player_podcast_path(podcast.random_url) do  %>
+            <%= image_tag(podcast.cover.url, size: "150x150") if podcast.cover? %>
+          <% end %>
           </div>
           </div>
         </div>

--- a/app/views/player/podcasts/show.html.erb
+++ b/app/views/player/podcasts/show.html.erb
@@ -4,12 +4,12 @@
   <div class="max-w-screen-lg mx-auto pt-10">
     <div class="">
       <span class="bg-genresbg m-10 py-1 px-5 text-white rounded-xl"><%= @podcast.genres %></span>
-      <div class="ms:flex m-10 md:flex">
-        <div class="cover_size pr-5">
+      <div class="m-10 md:flex">
+        <div class="pr-5 md:w-1/3">
           <%= image_tag(@podcast.cover.url, size: "300x300") if @podcast.cover? %>
         </div>
-        <div>
-          <ul class="">
+        <div class="md:w-2/3">
+          <ul>
             <li class="p-1 text-blue-300 text-xl"><%= @podcast.subtitle %></li>
             <li class="p-1 text-white text-4xl"><%= @podcast.name %></li>
             <li class="p-1 text-white"><%= @podcast.description %></li>


### PR DESCRIPTION
除了復刻贊助頁面 `player/donations/new_donation` 以外
同時修復 `podcasts/browse` & `podcasts/show` & `episodes/show` 頁面。

### 主要變更如下
- 贊助頁面預覽：
<img width="1243" alt="截圖 2021-06-01 下午5 19 01" src="https://user-images.githubusercontent.com/79676142/120299337-7f1c2f00-c2fd-11eb-8578-2cdc5ccad13e.png">


- Podcasts/browse：可顯示上傳的封面，並可點擊至該 Podcast 頁面
<img width="1243" alt="截圖 2021-06-01 下午5 17 00" src="https://user-images.githubusercontent.com/79676142/120299034-31072b80-c2fd-11eb-8d3f-9f6c155e89bd.png">