### PR TITLE
前台-Podcasts/browse 頁面 點擊移動橫軸

### DIFF
--- a/app/javascript/browser/browser.js
+++ b/app/javascript/browser/browser.js
@@ -6,13 +6,13 @@ document.addEventListener("turbolinks:load", function () {
 
   if (backArrow) {
     backArrow.addEventListener('click', function(){
-      document.querySelector('.wrapper').scrollLeft += 80;
+      document.querySelector('.wrapper').scrollLeft += 200;
     })
   }
 
   if (frontArrow) {
     frontArrow.addEventListener('click', function(){
-      document.querySelector('.wrapper').scrollLeft -= 80;
+      document.querySelector('.wrapper').scrollLeft -= 200;
     })
   }
 

--- a/app/javascript/browser/browser.js
+++ b/app/javascript/browser/browser.js
@@ -1,11 +1,18 @@
 document.addEventListener("turbolinks:load", function () {
 
   let backArrow = document.querySelector('#backArrow')
+  let frontArrow = document.querySelector('#frontArrow')
   let playerBtn = document.querySelector('#playerBtn')
 
   if (backArrow) {
     backArrow.addEventListener('click', function(){
-      document.querySelector('.wrapper').classList.add('move_back')
+      document.querySelector('.wrapper').scrollLeft += 80;
+    })
+  }
+
+  if (frontArrow) {
+    frontArrow.addEventListener('click', function(){
+      document.querySelector('.wrapper').scrollLeft -= 80;
     })
   }
 
@@ -14,10 +21,4 @@ document.addEventListener("turbolinks:load", function () {
       document.querySelector('.player').classList.toggle('hidden')
     })
   }
-
-  // if (playerBtn) {
-  //   playerBtn.addEventListener('click', function(){
-  //     document.querySelector('.player').classList.add('hidden')
-  //   })
-  // }
 })

--- a/app/javascript/styles/player.scss
+++ b/app/javascript/styles/player.scss
@@ -2,13 +2,12 @@
   @apply m-px transform hover:scale-110 transition duration-300;
 }
 
-
 .front_arrow {
-  @apply sticky left-0 z-10 bg-yellow-50 opacity-30 p-3 hover:opacity-50 duration-300;
+  @apply sticky h-16 my-auto left-0 z-10 bg-yellow-50 opacity-30 p-3 hover:opacity-50 duration-300;
 }
 
 .back_arrow {
-  @apply sticky right-0 z-10 bg-yellow-50 opacity-30 p-3 hover:opacity-50 duration-300;
+  @apply sticky h-16 my-auto right-0 z-10 bg-yellow-50 opacity-30 p-3 hover:opacity-50 duration-300;
 }
 
 .footerbg {
@@ -38,14 +37,12 @@
 .wrapper {
   display: flex;
   overflow-x: auto;
+  scroll-behavior: smooth; // 讓捲動 smooth 一點，不會瞬間跳過去
 }
 
 .covers {
   min-width: 150px;
   height: 150px;
-}
-
-.move_back {
 }
 
 .play_button {

--- a/app/javascript/styles/player.scss
+++ b/app/javascript/styles/player.scss
@@ -19,7 +19,7 @@
 }
 
 .footer_copyright {
-  @apply flex justify-center bg-footerbg text-gray-500 pb-5 pt-5 border-gray-400 border-t;
+  @apply flex justify-center bg-footerbg text-gray-500 pb-5 pt-5 border-gray-700 border-t;
 }
 
 .fb_icon {

--- a/app/views/frontend/_footer.html.erb
+++ b/app/views/frontend/_footer.html.erb
@@ -1,6 +1,6 @@
 <footer class="footerbg">
   <div class="flex flex-wrap justify-around">
-    <div class=""><%= link_to image_tag("logo_trans", size: "180x180"), "/#" %></div>
+    <div class="my-auto"><%= link_to image_tag("logo_trans", size: "180x180"), "/#" %></div>
     <div>
       <ul class="flex py-2">
         <li class="footer_link"><a href="">官方網站</a></li>

--- a/app/views/frontend/_header.html.erb
+++ b/app/views/frontend/_header.html.erb
@@ -1,8 +1,8 @@
-<header class="flex justify-between bg-indigo">
-  <div class="flex m-4 justify-center md:justify-start">
-    <%= link_to image_tag("logo_trans", size: "250x250"), "/#" %>
+<header class="flex justify-between bg-indigo pb-10">
+  <div class="flex m-6 justify-center md:justify-start">
+    <%= link_to image_tag("logo_trans", size: "220x220"), "/#" %>
   </div>
-  <form class="search-form border hover:border-blue-600 rounded flex my-auto mr-10">
-    <button class="search-btn focus:outline-none w-10 bg-white rounded-l text-gray-500 border-none p-2"><i class="fas fa-search"></i></button><input type="text" class="search-input focus:outline-none w-12 sm:w-40 md:w-60 lg:w-72 bg-white rounded-r border-none p-2" placeholder="搜尋 Podcast">
+  <form class="search-form border hover:border-blue-600 rounded-full flex my-auto mr-5">
+    <button class="search-btn focus:outline-none w-10 bg-white rounded-l-full text-gray-500 border-none p-2"><i class="fas fa-search"></i></button><input type="text" class="search-input focus:outline-none w-12 sm:w-40 md:w-60 bg-white rounded-r-full border-none p-2" placeholder="搜尋 Podcast">
   </form>
 </header>

--- a/app/views/player/donations/new_donation.html.erb
+++ b/app/views/player/donations/new_donation.html.erb
@@ -12,15 +12,21 @@
     <div class="w-full h-full grid">
       <div class="">
         <%= simple_form_for @donation, url:  donate_player_podcast_path(@podcast.random_url)  do |f| %>
-        <div class="p-3 pr-5 pl-5"><%= f.input :amount, label: "一次性贊助", input_html: { class: "donate_form" } %></div>
-        <div class="p-3 pr-5 pl-5"><%= f.input :donator, label: "名稱", placeholder: "未填寫則顯示「匿名贊助者」", input_html: { class: "donate_form" } %></div>
-        <div class="p-3 pr-5 pl-5"><%= f.input :note, label: "留一段話鼓勵我吧！", input_html: { class: "donate_message" } %></div>
-      </div>
-      <div>
+        <div class="p-3 pr-5 pl-5">
+          <%= f.input :amount, label: "一次性贊助", input_html: { class: "donate_form" } %>
+        </div>
+        <div class="p-3 pr-5 pl-5">
+          <%= f.input :donator, label: "名稱", placeholder: "未填寫則顯示「匿名贊助者」", input_html: { class: "donate_form" } %>
+        </div>
+        <div class="p-3 pr-5 pl-5">
+          <%= f.input :note, label: "留一段話鼓勵我吧！", input_html: { class: "donate_message" } %>
+        </div>
         <div class="flex flex-col justify-center flex-grow md:pt-64 pt-5 pr-7 pl-7 pb-3">
           <div><%= f.button :submit, "贊助", class: "btn-primary w-full" %></div>
         </div>
         <% end %>
+      </div>
+      <div>
         <footer class="flex text-xs font-light justify-center pb-3">
           <span class="pr-1">Powered</span>
           <span class="pr-1">by</span>

--- a/app/views/player/podcasts/browse.html.erb
+++ b/app/views/player/podcasts/browse.html.erb
@@ -12,17 +12,17 @@
       </div>
       <h2 class="text-white text-2xl mt-20 mb-6">新聲報到</h2>
       <div class="wrapper relative">
-        <button class="front_arrow">
+        <button id="frontArrow" class="front_arrow">
           <i class="fas fa-chevron-left"></i>
         </button>
         <% @podcasts.each do |podcast| %>
         <div class="cover_line imgBox">
           <div class="">
-          <div class="covers">
-          <%= link_to player_podcast_path(podcast.random_url) do  %>
-            <%= image_tag(podcast.cover.url, size: "150x150") if podcast.cover? %>
-          <% end %>
-          </div>
+            <div class="covers">
+              <%= link_to player_podcast_path(podcast.random_url) do  %>
+              <%= image_tag(podcast.cover.url, size: "150x150") if podcast.cover? %>
+              <% end %>
+            </div>
           </div>
         </div>
         <% end %>


### PR DESCRIPTION
實現點擊左右箭頭，可移動 Podcasts 封面橫軸區域。
- JS：`點擊事件＋scollLeft`
- CSS：`scroll-behavior: smooth`  使捲動較流暢，不會瞬間跳過去

PS: 
- 調整 header search bar 邊框 `rounded-full`
- 調整 footer logo y軸置中 `my-auto`