### PR TITLE
fix/create_episode

### DIFF
--- a/app/controllers/episodes_controller.rb
+++ b/app/controllers/episodes_controller.rb
@@ -14,7 +14,7 @@ class EpisodesController < ApplicationController
     if @episode.save
       redirect_to podcast_episodes_path(@podcast.random_url, @episode.random_url), notice: "新增單集成功"
     else
-      render :index
+      redirect_to podcast_episodes_path(@podcast.random_url, @episode.random_url), notice: "新增單集失敗"
     end
   end
 

--- a/app/views/episodes/index.html.erb
+++ b/app/views/episodes/index.html.erb
@@ -3,7 +3,7 @@
 </div>
 
 <!-- 新增單集燈箱 -->
-<div class="create-episode fixed w-full h-full bg-black bg-opacity-50 flex justify-end z-10 <%=' hidden' unless @episode.errors.any? %>">
+<div class="create-episode fixed w-full h-full bg-black bg-opacity-50 flex justify-end z-10 hidden">
   <div class="create-episode-content h-full bg-white flex justify-center relative">
     <nav class="fixed top-0 shadow-md">
       <div class="flex w-full justify-between">
@@ -28,7 +28,11 @@
       <section class="mainEpisode_content">
         <section class="w-full p-2 pr-5 flex flex-col text-sm">
           <label class="w-full border border-dashed rounded-md mx-2 my-3 py-4 px-6 focus:outline-none focus:border-blue-400 focus:ring focus:ring-blue-100 transition duration-300 cursor-pointer">
-            選擇要上傳的 mp3 音檔 <span class="mx-2 text-white pt-1 pb-2 px-4 text-sm bg-blue-500 hover:bg-blue-400 cursor-pointer transition duration-300 rounded">瀏覽</span>
+            <abbr title="required">*</abbr>
+            選擇要上傳的 mp3 音檔
+            <span class="mx-2 text-white pt-1 pb-2 px-4 text-sm bg-blue-500 hover:bg-blue-400 cursor-pointer transition duration-300 rounded">
+              瀏覽
+            </span>
             <%= f.input :recording, as: :file, input_html:{class: "hidden" }, label: false %>
           </label>
           <%= f.input :title, input_html:{class: "edit-form" }, label: "標題" %>

--- a/app/views/podcasts/index.html.erb
+++ b/app/views/podcasts/index.html.erb
@@ -1,5 +1,5 @@
 <!-- 建立Podcast燈箱 -->
-<div class="create-podcast fixed w-full h-full bg-black bg-opacity-50 flex justify-end z-10 <%= ' hidden' unless @podcast.errors.any? %>">
+<div class="create-podcast fixed w-full h-full bg-black bg-opacity-50 flex justify-end z-10 hidden">
   <div class="create-podcast-content h-full bg-white flex justify-center relative">
     <nav class="fixed top-0 shadow-md">
       <div class="flex w-full justify-between">
@@ -18,8 +18,8 @@
         <div class="w-56 h-80 pr-2 pt-2 rounded flex flex-col flex-shrink-0 items-center">
           <div class="w-48 h-48 rounded-lg bg-gray-300"><%= image_tag(@podcast.cover.url) if @podcast.cover? %></div>
           <label class="border border-gray-300 my-2 mx-4 pt-1 px-4 text-sm bg-white hover:text-blue-400 hover:border-blue-400 cursor-pointer transition duration-300 rounded">
-          上傳封面圖片
-          <%= f.input :cover, as: :file, input_html:{class: "hidden" }, label: false %>
+            <abbr title="required">*</abbr>上傳封面圖片
+            <%= f.input :cover, as: :file, input_html:{class: "hidden" }, label: false %>
           </label>
         </div>
         <div class="w-full text-sm pr-4">
@@ -77,9 +77,13 @@
       <section class="mainEpisode_content">
         <section class="w-full p-2 pr-5 flex flex-col text-sm">
           <label class="w-full border border-dashed rounded-md mx-2 my-3 py-4 px-6 focus:outline-none focus:border-blue-400 focus:ring focus:ring-blue-100 transition duration-300 cursor-pointer">
-          選擇要上傳的 mp3 音檔 <span class="mx-2 text-white pt-1 pb-2 px-4 text-sm bg-blue-500 hover:bg-blue-400 cursor-pointer transition duration-300 rounded">瀏覽</span>
-          <%= f.input :recording, as: :file, input_html:{class: "hidden" }, label: false %>
-        </label>
+            <abbr title="required">*</abbr>
+            選擇要上傳的 mp3 音檔
+            <span class="mx-2 text-white pt-1 pb-2 px-4 text-sm bg-blue-500 hover:bg-blue-400 cursor-pointer transition duration-300 rounded">
+              瀏覽
+            </span>
+            <%= f.input :recording, as: :file, input_html:{class: "hidden" }, label: false %>
+          </label>
           <%= f.input :title, input_html:{class: "edit-form" }, label: "標題" %>
           <%= f.input :description, input_html:{class: "edit-form" }, label: "描述" %>
           <%= f.input :keyword, input_html:{class: "edit-form" }, label: "關鍵字" %>


### PR DESCRIPTION
- 建立 Podcast 的圖片欄位 及 新增單集 的 mp3 欄位，新增 *號 優化使用者體驗
- 建立失敗時會 redirect 而不是 render
  - 若是該頁面沒有其他節目或單集時，@podcasts 和 @episodes 會變成 nil ，導致沒有 each 方法而噴錯